### PR TITLE
Feat/add simulate flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ understanding of how it works to control the robots.
 Remember to configure the following properties correctly:
 
 1. [RobotState.java][robotstate]
-  * `HOST` and `PORT` - address to the server
+  * `HOST` - the address to the server
   * `name` - set the name of your robot
-  * `simulation` - set this to false before starting a real match, set to true if you want to test robot using simulations in web interface (colors read from color sensor gets ignored)
 2. [build.properties][build-properties]
   * `device.host` - enter the IP address of your robot here. After you have connected both your robot and your machine to
     the network, you'll be able to upload your code to the robot by running the `ant upload`.
@@ -76,7 +75,7 @@ The handout computers are already pre-configured with `ant`.
 
 ### Killing a stalled process with ant
 
-Sometimes you migth encounter a crashed app that locks your brick. In stead of rebooting your brick you may use the
+Sometimes you might encounter a crashed app that locks your brick. In stead of rebooting your brick you may use the
 ```ant stop``` command.
 
 ## Color Sensor calibration

--- a/src/no/itera/lego/message/Status.java
+++ b/src/no/itera/lego/message/Status.java
@@ -11,6 +11,7 @@ public class Status implements Message {
 
     public static final String TYPE = "status";
 
+    private final boolean simulate;
     /**
      * this is set to true when the server activates a match
      */
@@ -28,7 +29,8 @@ public class Status implements Message {
      */
     public final List<Color> colors;
 
-    public Status(boolean isActive, Color target, List<Color> colors) {
+    public Status(boolean simulate, boolean isActive, Color target, List<Color> colors) {
+        this.simulate = simulate;
         this.isActive = isActive;
         this.target = target;
         this.colors = colors;
@@ -43,10 +45,12 @@ public class Status implements Message {
                 add(Color.YELLOW);
             }
         };
-        return new Status(isActive, target, colors);
+        return new Status(true, isActive, target, colors);
     }
 
     public static Status fromJson(JSONObject object) {
+        boolean simulate = (boolean) object.get("simulate");
+
         boolean isActive = (boolean) object.get("isActive");
 
         Color target = Color.valueOf((String) object.get("target"));
@@ -57,7 +61,11 @@ public class Status implements Message {
         for (Object objColor : jsonColorsArray) {
             colors.add(Color.valueOf((String) objColor));
         }
-        return new Status(isActive, target, colors);
+        return new Status(simulate, isActive, target, colors);
+    }
+
+    public boolean isSimulation() {
+        return simulate;
     }
 
     public String toJson() {
@@ -66,8 +74,9 @@ public class Status implements Message {
 
     @Override
     public String toString() {
-        return String.format("%s{%s, %s, %s}",
+        return String.format("%s{%s, %s, %s, %s}",
                 getClass().getSimpleName(),
+                simulate,
                 isActive,
                 target,
                 colors);

--- a/src/no/itera/lego/message/Status.java
+++ b/src/no/itera/lego/message/Status.java
@@ -5,6 +5,7 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class Status implements Message {
@@ -37,14 +38,11 @@ public class Status implements Message {
     }
 
     public static Status createTestingStatus(boolean isActive, Color target, final Color currentColor){
-        List<Color> colors = new ArrayList<Color>() {
-            {
-                add(currentColor);
-                add(Color.BLUE);
-                add(Color.WHITE);
-                add(Color.YELLOW);
-            }
-        };
+        List<Color> colors = Arrays.asList(
+                currentColor,
+                Color.BLUE,
+                Color.WHITE,
+                Color.YELLOW);
         return new Status(true, isActive, target, colors);
     }
 

--- a/src/no/itera/lego/robot/RobotState.java
+++ b/src/no/itera/lego/robot/RobotState.java
@@ -14,15 +14,10 @@ public class RobotState {
      *      Enter the server address that the robot should connect to
      * name:
      *      The name of your robot
-     * simulation:
-     *      false - Set it to false when you are playing the real game
-     *      true - when you're testing your robot you can control it
-     *      through the simulation panel available from the server
      */
-    public static final String HOST = "192.168.43.168";
+    public static final String HOST = "192.168.43.254";
     public static final int PORT = 3004;
     public final String name = "YOUR ROBOT NAME";
-    public boolean simulation = true;
 
     /**
      * READ ONLY

--- a/src/no/itera/lego/websocket/WebSocketThread.java
+++ b/src/no/itera/lego/websocket/WebSocketThread.java
@@ -89,7 +89,7 @@ public class WebSocketThread implements Runnable {
     }
 
     private void sendColor() {
-        if (!robotState.simulation) {
+        if (!robotState.lastStatus.isSimulation()) {
             sendMessage(new Update(robotState.lastColor));
             lastHandledColor = robotState.lastColor;
         }


### PR DESCRIPTION
This PR updates the Status object of the websocket client to receive the `simulate` flag that has been added to the server instead. We tested this on monday, and it allows for the server to control whether the robot should be in simulate mode when testing, or not when a match is running.